### PR TITLE
refactor!: replace google/uuid with standard library uuid (Go 1.27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ id := xuid.MustNewRandom("order")
 #### From Existing UUID
 
 ```go
-import "github.com/google/uuid"
-
 existingUUID := uuid.New()
 id, err := xuid.NewWith(existingUUID, "custom")
 ```
+
+> Requires Go 1.27+ for the standard library `uuid` package.
 
 #### Nil UUID
 
@@ -204,8 +204,8 @@ var (
 
 ## Dependencies
 
-- `github.com/google/uuid` - UUID generation and manipulation
 - `github.com/btcsuite/btcd/btcutil/base58` - Base58 encoding
+- UUID generation uses the standard library `uuid` package (Go 1.27+)
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/47monad/xuid
 
-go 1.22.0
+go 1.27.0
 
 require (
 	github.com/btcsuite/btcd/btcutil v1.1.6
-	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/sql.go
+++ b/sql.go
@@ -3,14 +3,13 @@ package xuid
 import (
 	"database/sql/driver"
 	"errors"
-
-	"github.com/google/uuid"
+	"uuid"
 )
 
 // Value implements the driver.Valuer interface.
 // This allows XUID to be stored in SQL databases as UUID.
 func (x XUID) Value() (driver.Value, error) {
-	if x.uuid == uuid.Nil {
+	if x.uuid == uuid.Nil() {
 		return nil, nil
 	}
 	return x.uuid.String(), nil
@@ -22,7 +21,7 @@ func (x XUID) Value() (driver.Value, error) {
 // You should reconstruct XUIDs with their appropriate prefixes after loading.
 func (x *XUID) Scan(value interface{}) error {
 	if value == nil {
-		x.uuid = uuid.Nil
+		x.uuid = uuid.Nil()
 		x.prefix = ""
 		return nil
 	}
@@ -33,7 +32,7 @@ func (x *XUID) Scan(value interface{}) error {
 		if err != nil {
 			return errors.New("failed to scan from database. Invalid XUID string")
 		}
-		copy(x.uuid[:], id[:])
+		x.uuid = id
 		x.prefix = ""
 		return nil
 	case []byte:

--- a/sql_test.go
+++ b/sql_test.go
@@ -4,9 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"testing"
+	"uuid"
 
 	"github.com/47monad/xuid"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -78,7 +78,7 @@ func TestXUIDScan(t *testing.T) {
 		err := id.Scan(nil)
 
 		require.NoError(t, err)
-		assert.Equal(t, uuid.Nil, id.GetUUID())
+		assert.Equal(t, uuid.Nil(), id.GetUUID())
 		assert.Equal(t, "", id.GetPrefix())
 		assert.True(t, xuid.IsEmpty(id))
 	})

--- a/xuid.go
+++ b/xuid.go
@@ -23,9 +23,9 @@ package xuid
 import (
 	"errors"
 	"strings"
+	"uuid"
 
 	"github.com/btcsuite/btcd/btcutil/base58"
-	"github.com/google/uuid"
 )
 
 type XUID struct {
@@ -46,12 +46,8 @@ func NewWith(id uuid.UUID, prefix string) (XUID, error) {
 }
 
 func NewSortable(prefix string) (XUID, error) {
-	id, err := uuid.NewV7()
-	if err != nil {
-		return XUID{}, err
-	}
 	return XUID{
-		uuid:   id,
+		uuid:   uuid.NewV7(),
 		prefix: prefix,
 	}, nil
 }
@@ -61,12 +57,8 @@ func MustNewSortable(prefix string) XUID {
 }
 
 func NewRandom(prefix string) (XUID, error) {
-	id, err := uuid.NewRandom()
-	if err != nil {
-		return XUID{}, err
-	}
 	return XUID{
-		uuid:   id,
+		uuid:   uuid.NewV4(),
 		prefix: prefix,
 	}, nil
 }
@@ -76,7 +68,7 @@ func MustNewRandom(prefix string) XUID {
 }
 
 func NilUUID() (XUID, error) {
-	return NewWith(uuid.Nil, "")
+	return NewWith(uuid.Nil(), "")
 }
 
 func (x XUID) GetUUID() uuid.UUID {
@@ -84,11 +76,11 @@ func (x XUID) GetUUID() uuid.UUID {
 }
 
 func (x XUID) IsSortable() bool {
-	return x.GetUUID().Version().String() == "VERSION_7"
+	return x.uuid[6]>>4 == 7
 }
 
 func (x XUID) IsRandom() bool {
-	return x.GetUUID().Version().String() == "VERSION_4"
+	return x.uuid[6]>>4 == 4
 }
 
 func (x XUID) GetPrefix() string {
@@ -103,11 +95,10 @@ func (x *XUID) SetPrefix(prefix string) *XUID {
 }
 
 func (x XUID) String() string {
-	b, _ := x.uuid.MarshalBinary()
 	if x.prefix == "" {
-		return base58.Encode(b)
+		return base58.Encode(x.uuid[:])
 	}
-	return x.prefix + "_" + base58.Encode(b)
+	return x.prefix + "_" + base58.Encode(x.uuid[:])
 }
 
 func (x XUID) Equal(y XUID) bool {
@@ -122,10 +113,11 @@ func Parse(idstr string) (XUID, error) {
 		prefix = idstr[:underscoreIndex]
 	}
 	_str := base58.Decode(uuidstr)
-	_uuid, err := uuid.FromBytes(_str)
-	if err != nil {
+	var _uuid uuid.UUID
+	if len(_str) != len(_uuid) {
 		return XUID{}, ErrParse
 	}
+	copy(_uuid[:], _str)
 	return NewWith(_uuid, prefix)
 }
 
@@ -150,5 +142,5 @@ func Must(xid XUID, err error) XUID {
 }
 
 func IsEmpty(xid XUID) bool {
-	return xid.uuid == uuid.Nil
+	return xid.uuid == uuid.Nil()
 }

--- a/xuid_test.go
+++ b/xuid_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"uuid"
 
 	"github.com/47monad/xuid"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ func TestNewSortable(t *testing.T) {
 		assert.True(t, id.IsSortable())
 		assert.False(t, id.IsRandom())
 		assert.Equal(t, "user", id.GetPrefix())
-		assert.NotEqual(t, uuid.Nil, id.GetUUID())
+		assert.NotEqual(t, uuid.Nil(), id.GetUUID())
 	})
 
 	t.Run("creates sortable XUID without prefix", func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestNewRandom(t *testing.T) {
 		assert.True(t, id.IsRandom())
 		assert.False(t, id.IsSortable())
 		assert.Equal(t, "session", id.GetPrefix())
-		assert.NotEqual(t, uuid.Nil, id.GetUUID())
+		assert.NotEqual(t, uuid.Nil(), id.GetUUID())
 	})
 
 	t.Run("creates random XUID without prefix", func(t *testing.T) {
@@ -114,10 +114,10 @@ func TestNewWith(t *testing.T) {
 	})
 
 	t.Run("creates XUID with nil UUID", func(t *testing.T) {
-		id, err := xuid.NewWith(uuid.Nil, "empty")
+		id, err := xuid.NewWith(uuid.Nil(), "empty")
 
 		require.NoError(t, err)
-		assert.Equal(t, uuid.Nil, id.GetUUID())
+		assert.Equal(t, uuid.Nil(), id.GetUUID())
 		assert.Equal(t, "empty", id.GetPrefix())
 	})
 
@@ -145,7 +145,7 @@ func TestNilUUID(t *testing.T) {
 		id, err := xuid.NilUUID()
 
 		require.NoError(t, err)
-		assert.Equal(t, uuid.Nil, id.GetUUID())
+		assert.Equal(t, uuid.Nil(), id.GetUUID())
 		assert.Equal(t, "", id.GetPrefix())
 		assert.True(t, xuid.IsEmpty(id))
 	})
@@ -379,8 +379,9 @@ func TestVersionChecking(t *testing.T) {
 	})
 
 	t.Run("handles custom UUID versions", func(t *testing.T) {
-		// Using UUID v1 for testing
-		customUUID, _ := uuid.NewUUID()
+		// Using UUID v1 for testing (stdlib uuid has no v1 constructor,
+		// so craft one by setting the version nibble directly)
+		customUUID := uuid.MustParse("550e8400-e29b-11d4-a716-446655440000") // version 1
 		id, _ := xuid.NewWith(customUUID, "test")
 
 		assert.False(t, id.IsSortable())


### PR DESCRIPTION
## Summary

Closes #3 and migrates the package to Go 1.27's new standard library `uuid` package (RFC 9562), removing `github.com/google/uuid` as a dependency.

## Changes

- **go.mod**: bump `go` directive to `1.27.0`, drop `github.com/google/uuid`
- **`IsSortable`/`IsRandom`** (#3): compare the UUID version nibble (`uuid[6]>>4`) numerically instead of matching `Version().String()` output — no allocation, and no dependence on a third-party library's human-facing string format
- **`NewSortable`/`NewRandom`**: stdlib `NewV7()`/`NewV4()` cannot fail, so internal error handling is gone. Public `(XUID, error)` signatures are kept for source compatibility (they now always return `nil`); dropping them entirely can follow as a separate breaking change
- **`Parse`**: replace `uuid.FromBytes` with an explicit 16-byte length check + copy (stdlib has no `FromBytes`)
- **`NilUUID`/`IsEmpty`/`Scan`/`Value`**: adapt to `uuid.Nil` being a function in the stdlib API
- **Tests**: `uuid.Nil()` call sites; the "custom version" test crafts a v1 UUID directly since the stdlib package has no v1 constructor
- **README**: dependencies section updated; Google UUID import example removed

## Breaking change

Requires **Go 1.27+** (standard library `uuid` package).

## Notes

- Public API signatures are otherwise unchanged.
- After merge, the only remaining external runtime dependency is `btcsuite/btcd/btcutil` (base58) — tracked in #13.