### PR TITLE
fix(json): map null to zero-value XUID in JSON round trip

### DIFF
--- a/json.go
+++ b/json.go
@@ -2,13 +2,29 @@ package xuid
 
 import (
 	"encoding/json"
+	"uuid"
 )
 
+// MarshalJSON implements the json.Marshaler interface.
+// A zero-value XUID (nil UUID, empty prefix) marshals to null,
+// mirroring the behavior of Value for SQL storage.
 func (x XUID) MarshalJSON() ([]byte, error) {
+	if x.uuid == uuid.Nil() {
+		return []byte("null"), nil
+	}
 	return json.Marshal(x.String())
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// null is accepted and maps to the zero-value XUID, mirroring
+// the behavior of Scan for SQL storage. Any other value must
+// be a valid XUID string.
 func (x *XUID) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		x.uuid = uuid.Nil()
+		x.prefix = ""
+		return nil
+	}
 	var res string
 	err := json.Unmarshal(data, &res)
 	if err != nil {

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,150 @@
+package xuid_test
+
+import (
+	"encoding/json"
+	"testing"
+	"uuid"
+
+	"github.com/47monad/xuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXUIDMarshalJSON(t *testing.T) {
+	t.Run("marshals valid XUID to string", func(t *testing.T) {
+		id := xuid.MustNewSortable("user")
+
+		data, err := json.Marshal(id)
+
+		require.NoError(t, err)
+		assert.Equal(t, `"`+id.String()+`"`, string(data))
+	})
+
+	t.Run("marshals XUID without prefix to string", func(t *testing.T) {
+		testUUID, _ := uuid.Parse("550e8400-e29b-41d4-a716-446655440000")
+		id, _ := xuid.NewWith(testUUID, "")
+
+		data, err := json.Marshal(id)
+
+		require.NoError(t, err)
+		assert.Equal(t, `"`+id.String()+`"`, string(data))
+	})
+
+	t.Run("marshals zero-value XUID to null", func(t *testing.T) {
+		var id xuid.XUID
+
+		data, err := json.Marshal(id)
+
+		require.NoError(t, err)
+		assert.Equal(t, "null", string(data))
+	})
+
+	t.Run("marshals nil UUID XUID to null", func(t *testing.T) {
+		id, _ := xuid.NilUUID()
+
+		data, err := json.Marshal(id)
+
+		require.NoError(t, err)
+		assert.Equal(t, "null", string(data))
+	})
+
+	t.Run("implements json.Marshaler interface", func(t *testing.T) {
+		var _ json.Marshaler = xuid.XUID{}
+	})
+}
+
+func TestXUIDUnmarshalJSON(t *testing.T) {
+	t.Run("unmarshals prefixed XUID string", func(t *testing.T) {
+		original := xuid.MustNewSortable("user")
+		var id xuid.XUID
+
+		err := json.Unmarshal([]byte(`"`+original.String()+`"`), &id)
+
+		require.NoError(t, err)
+		assert.True(t, original.Equal(id))
+		assert.Equal(t, "user", id.GetPrefix())
+	})
+
+	t.Run("unmarshals XUID string without prefix", func(t *testing.T) {
+		testUUID, _ := uuid.Parse("550e8400-e29b-41d4-a716-446655440000")
+		original, _ := xuid.NewWith(testUUID, "")
+		var id xuid.XUID
+
+		err := json.Unmarshal([]byte(`"`+original.String()+`"`), &id)
+
+		require.NoError(t, err)
+		assert.Equal(t, testUUID, id.GetUUID())
+		assert.Equal(t, "", id.GetPrefix())
+	})
+
+	t.Run("unmarshals null to zero-value XUID", func(t *testing.T) {
+		var id xuid.XUID
+
+		err := json.Unmarshal([]byte("null"), &id)
+
+		require.NoError(t, err)
+		assert.Equal(t, uuid.Nil(), id.GetUUID())
+		assert.Equal(t, "", id.GetPrefix())
+		assert.True(t, xuid.IsEmpty(id))
+	})
+
+	t.Run("unmarshals null over existing value resets to zero-value XUID", func(t *testing.T) {
+		id := xuid.MustNewSortable("user")
+
+		err := json.Unmarshal([]byte("null"), &id)
+
+		require.NoError(t, err)
+		assert.True(t, xuid.IsEmpty(id))
+	})
+
+	t.Run("returns error for invalid XUID string", func(t *testing.T) {
+		var id xuid.XUID
+
+		err := json.Unmarshal([]byte(`"not-an-xuid"`), &id)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error for non-string JSON value", func(t *testing.T) {
+		var id xuid.XUID
+
+		err := json.Unmarshal([]byte("123"), &id)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("implements json.Unmarshaler interface", func(t *testing.T) {
+		var _ json.Unmarshaler = (*xuid.XUID)(nil)
+	})
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	t.Run("complete JSON round trip preserves UUID and prefix", func(t *testing.T) {
+		original := xuid.MustNewSortable("user")
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var loaded xuid.XUID
+		err = json.Unmarshal(data, &loaded)
+		require.NoError(t, err)
+
+		assert.True(t, original.Equal(loaded))
+		assert.Equal(t, original.GetPrefix(), loaded.GetPrefix())
+		assert.Equal(t, original.GetUUID(), loaded.GetUUID())
+	})
+
+	t.Run("handles nil UUID round trip", func(t *testing.T) {
+		original, _ := xuid.NilUUID()
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+		assert.Equal(t, "null", string(data))
+
+		var loaded xuid.XUID
+		err = json.Unmarshal(data, &loaded)
+		require.NoError(t, err)
+
+		assert.True(t, xuid.IsEmpty(loaded))
+	})
+}


### PR DESCRIPTION
## Summary

Fixes the two JSON encoding bugs reported in #5:

1. **`null` unmarshal failure**: `UnmarshalJSON` fed `"null"` into `Parse("")` and returned `ErrParse`. It now accepts `null` and maps it to the zero-value `XUID` (nil UUID, empty prefix), mirroring `Scan(nil)` from the SQL layer.
2. **Zero-value corruption vector**: `MarshalJSON` on a zero-value `XUID` emitted `"1111111111111111"` — a string that parses back as a valid (nil-UUID) XUID. It now emits `null`, mirroring `Value()` from the SQL layer.

Non-null strings must still parse as valid XUIDs.

## Contract

- `null` ⇔ zero `XUID` (nil UUID, empty prefix), consistent with SQL `Value`/`Scan`
- Non-null JSON strings must parse as XUIDs; anything else errors

## Testing

- New `json_test.go` following the existing `sql_test.go` style:
  - Marshal: valid XUID → quoted string; zero-value / nil-UUID → `null`
  - Unmarshal: prefixed & unprefixed strings; `null` → zero value (including resetting an existing value); invalid string and non-string → errors
  - Round trips for valid and nil-UUID values
- `go build`, `go test`, `go vet`, `gofmt` all clean

Fixes #5