### PR TITLE
fix: compare XUID fields in Equal; add EqualUUID, Compare and Less

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,27 @@ if xuid.IsEmpty(id) {
 id1 := xuid.MustNewSortable("user")
 id2 := xuid.MustNewSortable("user")
 
+// Equal compares both the UUID and the prefix: a different prefix
+// means the identifiers are not equal, even with the same UUID.
 if id1.Equal(id2) {
     fmt.Println("XUIDs are equal")
 }
+
+// EqualUUID compares only the underlying UUIDs, ignoring prefixes.
+if id1.EqualUUID(id2) {
+    fmt.Println("Same identifier, prefix ignored")
+}
+
+// Compare orders XUIDs by prefix first (empty prefix sorts first),
+// then by UUID bytes. For UUIDv7 IDs sharing a prefix, this is
+// chronological order.
+if xuid.Compare(id1, id2) < 0 {
+    fmt.Println("id1 sorts before id2")
+}
+
+// Sort a slice of XUIDs.
+ids := []xuid.XUID{id2, id1}
+slices.SortFunc(ids, xuid.Compare)
 ```
 
 ### JSON Support

--- a/xuid.go
+++ b/xuid.go
@@ -99,8 +99,48 @@ func (x XUID) String() string {
 	return x.prefix + "_" + encodeBase58(x.uuid[:])
 }
 
+// Equal reports whether x and y identify the same XUID.
+//
+// Two XUIDs are equal only if both their UUID and prefix match.
+// A different prefix means the identifiers are not equal, even when
+// they carry the same UUID, because the prefix is part of the
+// identifier's identity. To compare only the underlying UUIDs,
+// use EqualUUID.
 func (x XUID) Equal(y XUID) bool {
-	return x.String() == y.String()
+	return x.uuid == y.uuid && x.prefix == y.prefix
+}
+
+// EqualUUID reports whether x and y carry the same UUID, ignoring
+// their prefixes. It is useful when the same identifier is stored
+// under different prefixes (e.g. after restoring a prefix from a
+// database column).
+func (x XUID) EqualUUID(y XUID) bool {
+	return x.uuid == y.uuid
+}
+
+// Compare returns an integer comparing two XUIDs.
+//
+// The result is -1 if x sorts before y, 0 if x and y are ordered
+// identically, and +1 if x sorts after y.
+//
+// XUIDs are ordered by prefix first (an empty prefix sorts before
+// any non-empty prefix), then by UUID bytes. For UUIDv7 identifiers
+// sharing a prefix, the UUID bytes preserve chronological order, so
+// Compare yields time-ordered results within each prefix.
+//
+// Note that Compare treats XUIDs as ordered values, not identical
+// ones: Compare returns 0 only when both prefix and UUID match.
+func Compare(x, y XUID) int {
+	if c := strings.Compare(x.prefix, y.prefix); c != 0 {
+		return c
+	}
+	return x.uuid.Compare(y.uuid)
+}
+
+// Less reports whether x sorts before y. It is equivalent to
+// Compare(x, y) < 0.
+func Less(x, y XUID) bool {
+	return Compare(x, y) < 0
 }
 
 func Parse(idstr string) (XUID, error) {

--- a/xuid_test.go
+++ b/xuid_test.go
@@ -2,8 +2,10 @@ package xuid_test
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 	"uuid"
 
 	"github.com/47monad/xuid"
@@ -200,6 +202,118 @@ func TestXUIDEqual(t *testing.T) {
 		id2, _ := xuid.NewWith(testUUID, "test2")
 
 		assert.False(t, id1.Equal(id2))
+	})
+
+	t.Run("does not depend on string encoding", func(t *testing.T) {
+		testUUID := uuid.New()
+		id1, _ := xuid.NewWith(testUUID, "")
+		id2, _ := xuid.NewWith(testUUID, "")
+		require.Equal(t, id1.String(), id2.String())
+		assert.True(t, id1.Equal(id2))
+	})
+}
+
+func TestXUIDEqualUUID(t *testing.T) {
+	t.Run("returns true for same UUID with different prefixes", func(t *testing.T) {
+		testUUID := uuid.New()
+		id1, _ := xuid.NewWith(testUUID, "user")
+		id2, _ := xuid.NewWith(testUUID, "order")
+
+		assert.True(t, id1.EqualUUID(id2))
+		assert.False(t, id1.Equal(id2))
+	})
+
+	t.Run("returns true for same UUID ignoring empty prefix", func(t *testing.T) {
+		testUUID := uuid.New()
+		id1, _ := xuid.NewWith(testUUID, "")
+		id2, _ := xuid.NewWith(testUUID, "user")
+
+		assert.True(t, id1.EqualUUID(id2))
+	})
+
+	t.Run("returns false for different UUIDs", func(t *testing.T) {
+		id1, _ := xuid.NewWith(uuid.New(), "test")
+		id2, _ := xuid.NewWith(uuid.New(), "test")
+
+		assert.False(t, id1.EqualUUID(id2))
+	})
+}
+
+func TestCompare(t *testing.T) {
+	t.Run("returns 0 for equal XUIDs", func(t *testing.T) {
+		testUUID := uuid.New()
+		id1, _ := xuid.NewWith(testUUID, "test")
+		id2, _ := xuid.NewWith(testUUID, "test")
+
+		assert.Equal(t, 0, xuid.Compare(id1, id2))
+	})
+
+	t.Run("returns 0 only when prefix and UUID match", func(t *testing.T) {
+		testUUID := uuid.New()
+		id1, _ := xuid.NewWith(testUUID, "user")
+		id2, _ := xuid.NewWith(testUUID, "order")
+
+		assert.NotEqual(t, 0, xuid.Compare(id1, id2))
+	})
+
+	t.Run("sorts by prefix before UUID", func(t *testing.T) {
+		id1, _ := xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000001"), "a")
+		id2, _ := xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000000"), "b")
+
+		assert.Equal(t, -1, xuid.Compare(id1, id2))
+		assert.Equal(t, 1, xuid.Compare(id2, id1))
+	})
+
+	t.Run("sorts empty prefix before non-empty prefix", func(t *testing.T) {
+		id1, _ := xuid.NewWith(uuid.New(), "")
+		id2, _ := xuid.NewWith(uuid.New(), "user")
+
+		assert.Equal(t, -1, xuid.Compare(id1, id2))
+		assert.Equal(t, 1, xuid.Compare(id2, id1))
+	})
+
+	t.Run("sorts by UUID bytes for equal prefixes", func(t *testing.T) {
+		id1, _ := xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000001"), "test")
+		id2, _ := xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000002"), "test")
+
+		assert.Equal(t, -1, xuid.Compare(id1, id2))
+		assert.Equal(t, 1, xuid.Compare(id2, id1))
+		assert.Equal(t, 0, xuid.Compare(id1, id1))
+	})
+
+	t.Run("preserves chronological order for UUIDv7 with same prefix", func(t *testing.T) {
+		id1 := xuid.MustNewSortable("user")
+		time.Sleep(2 * time.Millisecond)
+		id2 := xuid.MustNewSortable("user")
+
+		assert.Equal(t, -1, xuid.Compare(id1, id2))
+		assert.Equal(t, 1, xuid.Compare(id2, id1))
+	})
+
+	t.Run("sorts a slice of XUIDs", func(t *testing.T) {
+		ids := []xuid.XUID{
+			xuid.Must(xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000002"), "user")),
+			xuid.Must(xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000001"), "user")),
+			xuid.Must(xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000001"), "order")),
+			xuid.Must(xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000000"), "")),
+		}
+		slices.SortFunc(ids, xuid.Compare)
+
+		assert.Equal(t, "", ids[0].GetPrefix())
+		assert.Equal(t, "order", ids[1].GetPrefix())
+		assert.Equal(t, "00000000-0000-7000-8000-000000000001", ids[2].GetUUID().String())
+		assert.Equal(t, "00000000-0000-7000-8000-000000000002", ids[3].GetUUID().String())
+	})
+}
+
+func TestLess(t *testing.T) {
+	t.Run("matches Compare", func(t *testing.T) {
+		id1, _ := xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000001"), "test")
+		id2, _ := xuid.NewWith(uuid.MustParse("00000000-0000-7000-8000-000000000002"), "test")
+
+		assert.True(t, xuid.Less(id1, id2))
+		assert.False(t, xuid.Less(id2, id1))
+		assert.False(t, xuid.Less(id1, id1))
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes #4.

- **`Equal`** now compares fields directly (`uuid` and `prefix`) instead of base58-encoding both operands on every call, which was wasteful in hot paths. Prefix semantics are now documented: prefix is part of identity, so same UUID + different prefix ⇒ not equal.
- **`EqualUUID`** (new) compares only the underlying UUIDs, ignoring prefixes — for cases like restoring a prefix from a database column.
- **`Compare`** (new) orders XUIDs by prefix first (empty prefix sorts first), then by UUID bytes. For UUIDv7 IDs sharing a prefix, this yields chronological order. `Compare` returns 0 only when both prefix and UUID match, so it stays consistent with `Equal`.
- **`Less`** (new) reports whether one XUID sorts before another (`Compare(x, y) < 0`), enabling `sort.Slice` / `sort.Interface`-style usage; `Compare` works directly with `slices.SortFunc`.

## Notes

- Ordering semantics were decided as: prefix as primary key, UUID as secondary — groups by entity type and stays chronological within each prefix. Happy to flip if the maintainers prefer UUID-first ordering.
- README's Comparison section updated with the new API examples.

## Test plan

- `go vet ./...` and `go test ./...` pass.
- New tests cover: `Equal` field comparison, `EqualUUID` with differing/empty prefixes, `Compare` ordering by prefix and UUID, empty-prefix ordering, UUIDv7 chronological ordering within a prefix, sorting a `[]XUID` via `slices.SortFunc`, and `Less` consistency with `Compare`.